### PR TITLE
Update how lowest face is chosen

### DIFF
--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -76,8 +76,23 @@ def select_face(bboxes, frame, fc_model, fc_data_transforms, hor, ver, device):
             # crop_img = faces[idxs[i]]
             bbox = bboxes[idxs[i]]
             # hor, ver = centers[i]
-    else:   # select lowest face in image, probably belongs to kid
-        bbox = min(bboxes, key=lambda x: x[3] - x[1])
+    else:   # select face based on a mix of the lowest face and the width ratio of the face
+        bbox = None
+        prev_score = 0
+        for box in bboxes:
+            top_left_x, top_left_y, width, height = box
+            width_ratio = width / height
+            height_ratio = height / width
+            min_ratio = 1 / max(width_ratio, height_ratio)
+
+            box_bottom = top_left_y + height
+
+            box_score = min_ratio * box_bottom
+
+            # check if score outweighs previous bounding boxes
+            if box_score > prev_score:
+                prev_score = box_score
+                bbox = box
     return bbox
 
 def fix_illegal_transitions(loc, answers, confidences, illegal_transitions, corrected_transitions):

--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -87,9 +87,7 @@ def select_face(bboxes, frame, fc_model, fc_data_transforms, hor, ver, device):
             else:
                 # find min ratio of width and height which will weight box score
                 min_ratio = min(width, height) / max(width, height)
-    
                 box_bottom = top_left_y + height
-    
                 box_score = min_ratio * box_bottom
     
                 # check if score outweighs previous bounding boxes

--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -81,18 +81,21 @@ def select_face(bboxes, frame, fc_model, fc_data_transforms, hor, ver, device):
         prev_score = 0
         for box in bboxes:
             top_left_x, top_left_y, width, height = box
-            width_ratio = width / height
-            height_ratio = height / width
-            min_ratio = 1 / max(width_ratio, height_ratio)
-
-            box_bottom = top_left_y + height
-
-            box_score = min_ratio * box_bottom
-
-            # check if score outweighs previous bounding boxes
-            if box_score > prev_score:
-                prev_score = box_score
-                bbox = box
+            # make sure not dividing by zero
+            if width == 0 or height == 0:
+                continue
+            else:
+                # find min ratio of width and height which will weight box score
+                min_ratio = min(width, height) / max(width, height)
+    
+                box_bottom = top_left_y + height
+    
+                box_score = min_ratio * box_bottom
+    
+                # check if score outweighs previous bounding boxes
+                if box_score > prev_score:
+                    prev_score = box_score
+                    bbox = box
     return bbox
 
 def fix_illegal_transitions(loc, answers, confidences, illegal_transitions, corrected_transitions):


### PR DESCRIPTION
The previous lowest face selection (bbox = min(bboxes, key=lambda x: x[3] - x[1])) actually wasn't always selecting the lowest face ( because (0,0) coordinate is in the top left corner ). This is fixed, as well as a height/width ratio closer to 1 being favored. If you don't want this to be the default, I can change the addition of the ratio weight to a flag!