### PR TITLE
Added RegNet gaze model as the default option, added unit tests

### DIFF
--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -150,7 +150,7 @@ def load_models(opt):
                                processor=pooch.Unzip(),
                                progressbar=True)
     file_names = [Path(x).name for x in file_paths]
-    if opt.fd_model == "retinaface":  # option for retina face vs. previous opencv dnn model
+    if opt.fd_model == "retinaface":
         face_detector_model_file = file_paths[file_names.index("Resnet50_Final.pth")]
         face_detector_model = RetinaFace(
             gpu_id=opt.gpu_id, model_path=face_detector_model_file, network="resnet50"
@@ -161,21 +161,10 @@ def load_models(opt):
         face_detector_model = cv2.dnn.readNetFromCaffe(str(config_file), str(face_detector_model_file))
     else:
         raise NotImplementedError
-    path_to_gaze_model = Path(file_paths[file_names.index("icatcher+_lookit_regnet.pth")])
-    if opt.model:
-        if Path(opt.model).is_file():
-            path_to_gaze_model = opt.model
-        elif str(opt.model) in file_names:
-            path_to_gaze_model = Path(file_paths[file_names.index(str(opt.model))])
-    opt.path_to_gaze_model = path_to_gaze_model
-
-    path_to_fc_model = file_paths[file_names.index("face_classifier_lookit.pth")]
-    if opt.fc_model:
-        path_to_fc_model = opt.fc_model
-    # face_detector_model_file = Path("models", "face_model.caffemodel")
-    # config_file = Path("models", "config.prototxt")
-    # path_to_gaze_model = opt.model
-    gaze_model = models.GazeCodingModel(opt).to(opt.device)
+    path_to_gaze_model = Path(file_paths[file_names.index(opt.model)])
+    is_regnet = "regnet" in str(path_to_gaze_model.stem)
+    path_to_fc_model = file_paths[file_names.index(opt.fc_model)]
+    gaze_model = models.GazeCodingModel(opt, is_regnet=is_regnet).to(opt.device)
     if opt.device == 'cpu':
         state_dict = torch.load(str(path_to_gaze_model), map_location=torch.device(opt.device))
     else:
@@ -192,7 +181,7 @@ def load_models(opt):
         gaze_model.load_state_dict(new_state_dict)
     gaze_model.eval()
 
-    if opt.fc_model or opt.use_fc_model:
+    if opt.use_fc_model:
         face_classifier_model, fc_input_size = models.init_face_classifier(opt.device,
                                                                            num_classes=2,
                                                                            resume_from=path_to_fc_model)

--- a/src/icatcher/models.py
+++ b/src/icatcher/models.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn.functional as F
 from torchvision.models.resnet import resnet18
-from torchvision.models import vgg16
+from torchvision.models import vgg16, regnet_y_16gf
 from torchvision import transforms
 
 
@@ -108,7 +108,11 @@ class GazeCodingModel(torch.nn.Module):
         self.args = args
         self.n = (args.sliding_window_size + 1) // args.window_stride
         self.add_box = add_box
-        self.encoder_img = resnet18(num_classes=256).to(self.args.device)
+        if "regnet" in str(args.path_to_gaze_model.stem):
+            # Use the RegNet network architecture
+            self.encoder_img = regnet_y_16gf(num_classes=256).to(self.args.device)
+        else:
+            self.encoder_img = resnet18(num_classes=256).to(self.args.device)
         self.encoder_box = Encoder_box().to(self.args.device)
         self.predictor = Predictor_fc(self.n, add_box).to(self.args.device)
 

--- a/src/icatcher/models.py
+++ b/src/icatcher/models.py
@@ -103,12 +103,12 @@ class Encoder_box(torch.nn.Module):
         return x
 
 class GazeCodingModel(torch.nn.Module):
-    def __init__(self, args, add_box=True):
+    def __init__(self, args, is_regnet=True, add_box=True):
         super().__init__()
         self.args = args
         self.n = (args.sliding_window_size + 1) // args.window_stride
         self.add_box = add_box
-        if "regnet" in str(args.path_to_gaze_model.stem):
+        if is_regnet:
             # Use the RegNet network architecture
             self.encoder_img = regnet_y_16gf(num_classes=256).to(self.args.device)
         else:

--- a/src/icatcher/options.py
+++ b/src/icatcher/options.py
@@ -11,13 +11,20 @@ def parse_arguments(my_string=None):
     """
     parser = argparse.ArgumentParser(prog='icatcher')
     parser.add_argument("source", type=str, help="the source to use (path to video file, folder or webcam id)")
-    parser.add_argument("--model", type=str, help="path to model that will be used for predictions "
-                                                  "if not supplied will use model trained on the lookit dataset")
+    parser.add_argument("--model", type=str, default="icatcher+_lookit_regnet.pth", 
+                        choices=["icatcher+_lookit.pth",
+                                 "icatcher+_lookit_regnet.pth",
+                                 "icatcher+_bw-cali.pth",
+                                 "icatcher+_senegal.pth"],
+                        help="model file that will be used for gaze detection")
     parser.add_argument("--use_fc_model", action="store_true", help="if supplied, will use face classifier "
-                                                                              "to decide which crop to use from every frame.")
-    parser.add_argument("--fc_model", type=str, help="path to face classifier model that will be used for deciding "
-                                                     "which crop should we select from every frame. "
-                                                     "if not supplied but use_fc_model is true, will use the model trained on the lookit dataset.")
+                                                                    "to decide which crop to use from every frame.")
+    parser.add_argument("--fc_model", type=str, default="face_classifier_lookit.pth",
+                        choices=["face_classifier_lookit.pth",
+                                 "face_classifier_cali-bw.pth",
+                                  "face_classifier_senegal.pth"],
+                        help="face classifier model file that will be used for deciding "
+                                                     "which crop should we select from every frame. ")
     parser.add_argument("--source_type", type=str, default="file", choices=["file", "webcam"],
                         help="selects source of stream to use.")
     parser.add_argument("--crop_percent", type=int, default=0, help="A percent to crop video frames to prevent other people from appearing")
@@ -71,15 +78,11 @@ def parse_arguments(my_string=None):
         args = parser.parse_args(my_string.split())
     else:
         args = parser.parse_args()
-    if args.model:
-        args.model = Path(args.model)
     if args.fd_confidence_threshold is None:  # set defaults outside argparse to avoid complication
         if args.fd_model == "retinaface":
             args.fd_confidence_threshold = 0.9
         elif args.fd_model == "opencv_dnn":
             args.fd_confidence_threshold = 0.7
-    # if not args.model.is_file():
-    #     raise FileNotFoundError("Model file not found")
     if args.crop_percent not in [x for x in range(100)]:
         raise ValueError("crop_video must be a percent between 0 - 99")
     if "left" in args.crop_mode and "right" in args.crop_mode:

--- a/tests/test_gaze_model.py
+++ b/tests/test_gaze_model.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+from icatcher.cli import load_models, predict_from_video
+from icatcher.options import parse_arguments
+
+
+@pytest.mark.parametrize(
+    "args_string, model_path_stem, model_class_name",
+    [
+        ("tests/test_data/test.mp4", "icatcher+_lookit_regnet", "RegNet"),
+        (
+            "tests/test_data/test.mp4 --model icatcher+_lookit_regnet.pth",
+            "icatcher+_lookit_regnet",
+            "RegNet",
+        ),
+        (
+            "tests/test_data/test.mp4 --model icatcher+_lookit.pth",
+            "icatcher+_lookit",
+            "ResNet",
+        ),
+    ],
+)
+def test_load_models(args_string, model_path_stem, model_class_name):
+    """
+    Checks that when load_model is called with the gaze model:
+        1. left unspecified, RegNet trained on Lookit is called
+        2. specified as "icatcher+_lookit_regnet.pth", RegNet trained on Lookit is called
+        3. specified as "icatcher+_lookit.pth", ResNet trained on Lookit is called
+    """
+
+    args = parse_arguments(args_string)
+    gaze_model, _, _, _ = load_models(args)
+    assert args.path_to_gaze_model.stem == model_path_stem
+    assert gaze_model.encoder_img.__class__.__name__ == model_class_name
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Requires GPU for running, otherwise will timeout fail.",
+)
+@pytest.mark.parametrize(
+    "args_string",
+    [
+        "tests/test_data/test.mp4 --model icatcher+_lookit_regnet.pth --gpu_id=0",
+        "tests/test_data/test.mp4 --model icatcher+_lookit.pth --gpu_id=0",
+    ],
+)
+def test_predict_from_video(args_string):
+    """
+    Ensures that the entire prediction pipeline is run to completion with both gaze models.
+    """
+    args = parse_arguments(args_string)
+    predict_from_video(args)

--- a/tests/test_gaze_model.py
+++ b/tests/test_gaze_model.py
@@ -5,22 +5,22 @@ from icatcher.options import parse_arguments
 
 
 @pytest.mark.parametrize(
-    "args_string, model_path_stem, model_class_name",
+    "args_string, model_class_name",
     [
-        ("tests/test_data/test.mp4", "icatcher+_lookit_regnet", "RegNet"),
+        ("tests/test_data/test.mp4",
+        "RegNet"
+        ),
         (
             "tests/test_data/test.mp4 --model icatcher+_lookit_regnet.pth",
-            "icatcher+_lookit_regnet",
             "RegNet",
         ),
         (
             "tests/test_data/test.mp4 --model icatcher+_lookit.pth",
-            "icatcher+_lookit",
             "ResNet",
         ),
     ],
 )
-def test_load_models(args_string, model_path_stem, model_class_name):
+def test_load_models(args_string, model_class_name):
     """
     Checks that when load_model is called with the gaze model:
         1. left unspecified, RegNet trained on Lookit is called
@@ -30,7 +30,6 @@ def test_load_models(args_string, model_path_stem, model_class_name):
 
     args = parse_arguments(args_string)
     gaze_model, _, _, _ = load_models(args)
-    assert args.path_to_gaze_model.stem == model_path_stem
     assert gaze_model.encoder_img.__class__.__name__ == model_class_name
 
 


### PR DESCRIPTION
Changed the model loading code to include an option for choosing the gaze model. If no model is specified, by default, the RegNet image encoder trained on Lookit will be loaded. In particular, those are the four cases:

1. `--model` is left unspecified: Loads the RegNet image encoder trained on Lookit as part of the GazeCodingModel.
2. `--model=icatcher+_lookit_regnet.pth`: Loads the RegNet image encoder trained on Lookit as part of the GazeCodingModel.
3. `--model=icatcher+_lookit.pth`: Loads the ResNet image encoder trained on Lookit as part of the GazeCodingModel.
4. `--model=my_own_model_path`: Loads the model specified by the path provided by the user. For now, it assumes that the model uses a ResNet image encoder backbone, for backward compatibility.


In addition, added three unit tests that test the model loading functionality in cases 1-3 above. For case 4, including a model in the repository seems like a huge and unjustified storage lift. Still, I could add functionality to download a model, load it, and then delete it if you think that's appropriate. Additional test cases make sure that the entire inference pipeline runs to completion with both gaze models. However, this option is only enabled for GPU devices, otherwise, it will timeout on the GitHub Actions automatic testing workflow.