### PR TITLE
Sw/fix crashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "tqdm",
     "pooch",
     "batch-face",
-    "pathos"
+    "pathos",
+    "psutil",
 ]
 requires-python = ">=3.9"
 

--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -281,8 +281,10 @@ def create_output_streams(video_path, framerate, resolution, opt):
                 if opt.overwrite:
                     prediction_output_file.unlink()
                 else:
-                    raise FileExistsError("Annotation output file already exists. Use --overwrite flag to overwrite.")
-            
+                    raise FileExistsError(
+                        "Annotation output file already exists. Use --overwrite flag to overwrite."
+                    )
+
     return video_output_file, prediction_output_file, skip
 
 
@@ -528,7 +530,7 @@ def predict_from_video(opt):
                     if class_text == "left":
                         class_text = "right"
                     elif class_text == "right":
-                        class_text = "left"                    
+                        class_text = "left"
                 if opt.on_off:
                     class_text = "off" if class_text == "away" else "on"
                 if opt.output_video_path:

--- a/src/icatcher/cli.py
+++ b/src/icatcher/cli.py
@@ -379,7 +379,9 @@ def predict_from_video(opt):
 
             # get available system memory, estimate safe batch size based on available me and frame size
             available_memory = psutil.virtual_memory().available  # in bytes
-            processing_batch_size = int((opt.available_ram_percentage * available_memory) // frame_memory)  # default is 75% available RAM
+            processing_batch_size = int(
+                (opt.available_ram_percentage * available_memory) // frame_memory
+            )  # default is 75% available RAM
 
             # send all frames in to be preprocessed and have faces detected prior to running gaze detection
             total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -402,7 +404,9 @@ def predict_from_video(opt):
                     processed_frames[0].shape[0],
                     processed_frames[0].shape[1],
                 )
-                logging.info(f"performing face detection on buffered frames... batch {batch_counter} of {total_batches}")
+                logging.info(
+                    f"performing face detection on buffered frames... batch {batch_counter} of {total_batches}"
+                )
                 faces = parallelize_face_detection(
                     processed_frames, face_detector_model, opt.fd_num_cpus, opt
                 )

--- a/src/icatcher/options.py
+++ b/src/icatcher/options.py
@@ -167,6 +167,12 @@ def parse_arguments(my_string=None):
         help="(cpu, retinaface only) face detection will be parallelized, by batching the frames (requires buffering them), increasing memory usage, but decreasing overall processing time. Disallows live stream of results.",
     )
     parser.add_argument(
+        "--available_ram_percentage",
+        type=float,
+        default=0.75,
+        help="The amount of available RAM utilized when creating batches of frames to be processed.",
+    )
+    parser.add_argument(
         "--fd_num_cpus",
         type=int,
         default=-1,

--- a/src/icatcher/options.py
+++ b/src/icatcher/options.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from . import version
 from pathos.helpers import cpu_count
 
+
 def parse_arguments(my_string=None):
     """
     parse command line arguments
@@ -82,8 +83,9 @@ def parse_arguments(my_string=None):
         "--output_annotation", type=str, help="Folder to output annotations to."
     )
     parser.add_argument(
-        "--overwrite", action="store_true",
-        help="If an output annotation file exists, will overwrite it. Without this flag iCatcher+ will terminate upon encountering an existing annotation file." 
+        "--overwrite",
+        action="store_true",
+        help="If an output annotation file exists, will overwrite it. Without this flag iCatcher+ will terminate upon encountering an existing annotation file.",
     )
     parser.add_argument(
         "--on_off",

--- a/src/icatcher/video.py
+++ b/src/icatcher/video.py
@@ -163,5 +163,7 @@ def get_video_paths(opt):
             )
     else:
         # video_paths = [int(opt.source)]
-        raise NotImplementedError("sources other than video file or folder of videos are not currently supported.")
+        raise NotImplementedError(
+            "sources other than video file or folder of videos are not currently supported."
+        )
     return video_paths

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import icatcher
 from icatcher.cli import predict_from_video
 from pathlib import Path
 
+
 def test_parse_illegal_transitions():
     """
     tests handling the option "illegal transitions".
@@ -73,7 +74,9 @@ def test_predict_from_video(args_string):
     if not args.overwrite:
         try:
             predict_from_video(args)
-        except FileExistsError: # should be raised if overwrite is False and file exists, which is expected since this is the second test
+        except (
+            FileExistsError
+        ):  # should be raised if overwrite is False and file exists, which is expected since this is the second test
             return
     else:
         predict_from_video(args)
@@ -88,7 +91,9 @@ def test_predict_from_video(args_string):
             with open(output_file, "r") as f:
                 data = f.readlines()
             predicted_classes = [x.split(",")[1].strip() for x in data]
-            predicted_classes = np.array([icatcher.classes[x] for x in predicted_classes])
+            predicted_classes = np.array(
+                [icatcher.classes[x] for x in predicted_classes]
+            )
             confidences = np.array([float(x.split(",")[2].strip()) for x in data])
         assert len(predicted_classes) == len(confidences)
         # assert len(predicted_classes) == 194 # hard coded number of frames in test video


### PR DESCRIPTION
These updates relate to the crashes occurring during parallel processing. Now, the available RAM of the user is checked and a default value of 75% of that is used to create batches of frames that are processed and sent off into parallel processes. This percentage was added as a flag that the user can change. (Also, feel free to change the default value if 75% is too high/low).