### PR TITLE
better command line options for ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ src/icatcher.egg-info/
 dist/
 build/
 node_modules/
+tests/test_data/test_short/
+tests/test_data/test_short.npz
+tests/test_data/test_short.txt

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can run iCatcher+ with the command:
 
 `icatcher --help`
 
-which will list all available options. The description below will help you get more familiar with some common command line arguments.
+Which will list all available options. Below we list some common options to help you get more familiar with iCatcher+. The pipeline is highly configurable, please see [the website](https://icatcherplus.github.io/) for more explanation about the flags.
 
 ### Annotating a Video
 To produce annotations for a video file (if a folder is provided, all videos will be used for prediction):
@@ -58,31 +58,31 @@ To produce annotations for a video file (if a folder is provided, all videos wil
 
 ### Common Flags
 
-You can save a labeled video by adding:
+- You can save a labeled video by adding:
 
 `--output_video_path /path/to/output_folder`
 
-If you want to output annotations to a file, use:
+- If you want to output annotations to a file, use:
 
 `--output_annotation /path/to/output_annotation_folder`
 
 See [Output format](#output-format) below for more information on how the files are formatted.
 
-To show the predictions online in a seperate window, add the option:
+- To show the predictions online in a seperate window, add the option:
 
 `--show_output`
 
-To launch the iCatcher+ web app (after annotating), use:
+- To launch the iCatcher+ [Web App](#web-app) (after annotating), use:
 
 `icatcher --app`
 
 The app should open automatically at [http://localhost:5001](http://localhost:5001). For more details, see [Web App](#web-app).
 
-Originally a face classifier was used to distinguish between adult and infant faces (however this can result in too much loss of data). It can be turned on by using:
+- Originally a face classifier was used to distinguish between adult and infant faces (however this can result in too much loss of data). It can be turned on by using:
 
 `icatcher /path/to/my/video.mp4 --use_fc_model`
 
-You can also add parameters to crop the video a given percent before passing to iCatcher: 
+- You can also add parameters to crop the video a given percent before passing to iCatcher: 
 
 `--crop_mode m` where `m` is any of [top, left, right], specifying which side of the video to crop from (if not provided, default is none; if crop_percent is provided but not crop_mode, default is top)
 
@@ -97,7 +97,6 @@ Currently we supports 3 output formats, though further formats can be added upon
 - **ui:** needed for viewing results in the web app; produces a directory of the following structure
 
         ├── decorated_frames     # dir containing annotated jpg files for each frame in the video
-        ├── video.mp4            # the original video
         ├── labels.txt           # file containing annotations in the `raw_output` format described above
 
 # Web App

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Currently we supports 3 output formats, though further formats can be added upon
 
 - **raw_output:** a file where each row will contain the frame number, the class prediction and the confidence of that prediction seperated by a comma
 - **compressed:** a npz file containing two numpy arrays, one encoding the predicted class (n x 1 int32) and another the confidence (n x 1 float32) where n is the number of frames. This file can be loaded into memory using the numpy.load function. For the map between class number and name see test.py ("predict_from_video" function).
-- **ui:** needed to open a video in the web app; produces a directory of the following structure
+- **ui:** needed for viewing results in the web app; produces a directory of the following structure
 
         ├── decorated_frames     # dir containing annotated jpg files for each frame in the video
         ├── video.mp4            # the original video

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To produce annotations for a video file (if a folder is provided, all videos wil
 
 `icatcher /path/to/my/video.mp4`
 
->**NOTE:** For any videos you wish to visualize with the [Web App](#web-app), you must use the `--output_annotation` and the `--output_format ui` flags:
->
->`icatcher /path/to/my/video.mp4 --output_annotation /path/to/desired/output/directory/ --output_format ui`
+**NOTE:** For any videos you wish to visualize with the [Web App](#web-app), you must use the `--output_annotation` and the `--output_format ui` flags:
+
+`icatcher /path/to/my/video.mp4 --output_annotation /path/to/desired/output/directory/ --output_format ui`
 
 ### Common Flags
 

--- a/README.md
+++ b/README.md
@@ -50,23 +50,11 @@ To produce annotations for a video file (if a folder is provided, all videos wil
 
 `icatcher /path/to/my/video.mp4`
 
->**NOTE:** For any videos you wish to visualize with the web app, you must use the `--ui_packaging_path` flag:
+>**NOTE:** For any videos you wish to visualize with the [Web App](#web-app), you must use the `--output_annotation` and the `--output_format ui` flags:
 >
->`icatcher /path/to/my/video.mp4 --ui_packaging_path /path/to/desired/output/directory/`
+>`icatcher /path/to/my/video.mp4 --output_annotation /path/to/desired/output/directory/ --output_format ui`
 
-### Using the iCatcher Web App
-To launch the iCatcher+ web app, use:
-
-`icatcher --app`
-
-The app should open automatically at [http://localhost:5001](http://localhost:5001). For more details, see [Web App](#web-app).
-
-### Common Annotation Flags
-A common option is to add:
-
-`icatcher /path/to/my/video.mp4 --use_fc_model`
-
-Which enables a child face detector for more robust results (however, sometimes this can result in too much loss of data).
+### Common Flags
 
 You can save a labeled video by adding:
 
@@ -76,9 +64,21 @@ If you want to output annotations to a file, use:
 
 `--output_annotation /path/to/output_annotation_folder`
 
+See [Output format](#output-format) below for more information on how the files are formatted.
+
 To show the predictions online in a seperate window, add the option:
 
 `--show_output`
+
+To launch the iCatcher+ web app (after annotating), use:
+
+`icatcher --app`
+
+The app should open automatically at [http://localhost:5001](http://localhost:5001). For more details, see [Web App](#web-app).
+
+Originally a face classifier was used to distinguish between adult and infant faces (however this can result in too much loss of data). It can be turned on by using:
+
+`icatcher /path/to/my/video.mp4 --use_fc_model`
 
 You can also add parameters to crop the video a given percent before passing to iCatcher: 
 
@@ -92,22 +92,22 @@ Currently we supports 3 output formats, though further formats can be added upon
 
 - **raw_output:** a file where each row will contain the frame number, the class prediction and the confidence of that prediction seperated by a comma
 - **compressed:** a npz file containing two numpy arrays, one encoding the predicted class (n x 1 int32) and another the confidence (n x 1 float32) where n is the number of frames. This file can be loaded into memory using the numpy.load function. For the map between class number and name see test.py ("predict_from_video" function).
-- **ui_output:** needed to open a video in the web app; produces a directory of the following structure
+- **ui:** needed to open a video in the web app; produces a directory of the following structure
 
         ├── decorated_frames     # dir containing annotated jpg files for each frame in the video
         ├── video.mp4            # the original video
-        ├── labels.txt           # file containing annotations in the `raw_output` form described above
+        ├── labels.txt           # file containing annotations in the `raw_output` format described above
 
 # Web App
 The iCatcher+ app is a tool that allows users to interact with output from the iCatcher+ ML pipeline in the browser. The tool is designed to operate entirely locally and will not upload any input files to remote servers.
 
 ### Using the UI
 
-When you open the iCatcher+ UI, you will be met with a pop-up inviting you to upload your video directory. Please note, this requires you to upload *the whole output directory* which should include a `labels.txt` file and a sub-directory containing all of the frame images from the video.
+When you open the iCatcher+ UI, you will be met with a pop-up inviting you to upload a directory. Please note, this requires you to upload *the whole output directory* which should include a `labels.txt` file and a sub-directory named `decorated_frames` containing all of the frames of the video as image files.
 
-Once you've submitted the video, you should see a pop-up asking if you want to upload the whole video. Rest assured, this will not upload those files through the internet or to any remote servers. This is only giving the local browser permission to access those files. The files will stay local to whatever computer is running the browser.
+Once you've uploaded a directory, you should see a pop-up asking whether you are sure want to upload all files. Rest assured, this will not upload the files to any remote servers. This is only giving the local browser permission to access those files. The files will stay local to whatever computer is running the browser.
 
-At this point, you should see your video on the screen (you may need to give it a few second to load). Now you can start to review your annotations. Below the video you'll see heatmaps giving you a visual overview of the labels for each frame, as well as the confidence level for each frame.
+At this point, you should see the video on the screen (you may need to give it a few second to load). Now you can start to review the annotations. Below the video you'll see heatmaps giving you a visual overview of the labels for each frame, as well as the confidence level for each frame.
 
 # Datasets access
 

--- a/src/icatcher/options.py
+++ b/src/icatcher/options.py
@@ -109,15 +109,12 @@ def parse_arguments(my_string=None):
         "--output_format",
         type=str,
         default="raw_output",
-        choices=["raw_output", "compressed"],
+        choices=["raw_output", "compressed", "ui"],
+        help="Selects output format.",
     )
     parser.add_argument(
         "--output_video_path",
         help="If present, annotated video will be saved to this folder.",
-    )
-    parser.add_argument(
-        "--ui_packaging_path",
-        help="If present, packages the output data into the UI format.",
     )
     parser.add_argument(
         "--pic_in_pic",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -87,6 +87,10 @@ def test_mask():
             "tests/test_data/test_short.mp4 --model icatcher+_lookit.pth --fd_model opencv_dnn --output_annotation tests/test_data --mirror_annotation --output_format compressed --overwrite",
             "tests/test_data/test_short_result.txt",
         ),
+        (
+            "tests/test_data/test_short.mp4 --model icatcher+_lookit.pth --fd_model opencv_dnn --output_annotation tests/test_data --output_format ui --overwrite",
+            "tests/test_data/test_short_result.txt",
+        ),
     ],
 )
 def test_predict_from_video(args_string, result_file):
@@ -116,8 +120,19 @@ def test_predict_from_video(args_string, result_file):
             data = np.load(output_file)
             predicted_classes = data["arr_0"]
             confidences = data["arr_1"]
-        else:
+        elif args.output_format == "raw_output":
             output_file = Path("tests/test_data/{}.txt".format(Path(args.source).stem))
+            with open(output_file, "r") as f:
+                data = f.readlines()
+            predicted_classes = [x.split(",")[1].strip() for x in data]
+            predicted_classes = np.array(
+                [icatcher.classes[x] for x in predicted_classes]
+            )
+            confidences = np.array([float(x.split(",")[2].strip()) for x in data])
+        elif args.output_format == "ui":
+            output_file = Path(
+                "tests/test_data/{}/labels.txt".format(Path(args.source).stem)
+            )
             with open(output_file, "r") as f:
                 data = f.readlines()
             predicted_classes = [x.split(",")[1].strip() for x in data]


### PR DESCRIPTION
This commit helps by removing the --ui_packaging_path flag which was slightly confusing, and instead add a --output_format ui, which makes more sense as the ui merely consumes another form of output form icatcher+.

Additionally, the video is not copied to output when --output_format ui is passed, as this is redundant (frames are being produced, and if user needs an annotated video there are other options for that).

Lastly, adds some basic tests with this flag, and updates the readme to help with #76.